### PR TITLE
Update CLI handling for SWI >6.4.1

### DIFF
--- a/shared/prolog/cli/appendxbgf.pro
+++ b/shared/prolog/cli/appendxbgf.pro
@@ -17,7 +17,9 @@ loadSequence(In,Xmls)
     !.
 
 main :- 
-   current_prolog_flag(argv,Argv),
+   % Compatibility hack for >6.4.1 and the use of '--'
+   ( RawArgv = argv ; RawArgv = os_argv ),
+   current_prolog_flag(RawArgv,Argv),
    append(_,['--',Out|Ins],Argv),
    maplist(loadSequence,Ins,Xmlss),
    concat(Xmlss,Xmls),

--- a/shared/prolog/cli/btf2bgf.pro
+++ b/shared/prolog/cli/btf2bgf.pro
@@ -3,7 +3,9 @@
 
 
 main :-
-   current_prolog_flag(argv,Argv),
+   % Compatibility hack for >6.4.1 and the use of '--'
+   ( RawArgv = argv ; RawArgv = os_argv ),
+   current_prolog_flag(RawArgv,Argv),
    append(_,['--',BtfFileIn,BgfFileOut],Argv),
    loadXml(BtfFileIn, BtfXml),
    xmlToRoot(BtfXml,Btf),

--- a/shared/prolog/cli/casexbgf.pro
+++ b/shared/prolog/cli/casexbgf.pro
@@ -77,7 +77,9 @@ testCase(Q,UD,X)
 
 
 main :- 
-   current_prolog_flag(argv,Argv),
+   % Compatibility hack for >6.4.1 and the use of '--'
+   ( RawArgv = argv ; RawArgv = os_argv ),
+   current_prolog_flag(RawArgv,Argv),
    append(_,['--',Mode,BgfFile,XbgfFile],Argv),
    require(
      casexbgf(Mode,Q,UD),

--- a/shared/prolog/cli/checkbtf.pro
+++ b/shared/prolog/cli/checkbtf.pro
@@ -3,7 +3,9 @@
 
 
 main :-
-   current_prolog_flag(argv,Argv),
+   % Compatibility hack for >6.4.1 and the use of '--'
+   ( RawArgv = argv ; RawArgv = os_argv ),
+   current_prolog_flag(RawArgv,Argv),
    append(_,['--',BtfFileIn],Argv),
    loadXml(BtfFileIn, BtfXml),
    xmlToRoot(BtfXml,Btf),

--- a/shared/prolog/cli/dcg2bgf.pro
+++ b/shared/prolog/cli/dcg2bgf.pro
@@ -87,7 +87,9 @@ readDcg(S,L)
      ). 
 
 :-
-   current_prolog_flag(argv,Argv),
+   % Compatibility hack for >6.4.1 and the use of '--'
+   ( RawArgv = argv ; RawArgv = os_argv ),
+   current_prolog_flag(RawArgv,Argv),
    append(_,['--',Input,Output],Argv),
    open(Input, read, IStream),
    readDcg(IStream, Dcg),

--- a/shared/prolog/cli/gbtf.pro
+++ b/shared/prolog/cli/gbtf.pro
@@ -161,7 +161,9 @@ cdbc(C,G,R,T)
 
 main 
  :- 
-    current_prolog_flag(argv,Argv),
+    % Compatibility hack for >6.4.1 and the use of '--'
+    ( RawArgv = argv ; RawArgv = os_argv ),
+    current_prolog_flag(RawArgv,Argv),
     append(_,['--',BgfFile|Options],Argv),
     nb_setval(options,Options),
     loadXml(BgfFile, XmlG),

--- a/shared/prolog/cli/gdt.pro
+++ b/shared/prolog/cli/gdt.pro
@@ -13,7 +13,9 @@ load_bgf(Uri,G3)
     !.
 
 main :- 
-   current_prolog_flag(argv,Argv),
+   % Compatibility hack for >6.4.1 and the use of '--'
+   ( RawArgv = argv ; RawArgv = os_argv ),
+   current_prolog_flag(RawArgv,Argv),
    append(_,['--'|L1],Argv),
    maplist(load_bgf,L1,Gs),
    zip(L1,Gs,L2),

--- a/shared/prolog/cli/onexsd2bgf.pro
+++ b/shared/prolog/cli/onexsd2bgf.pro
@@ -28,7 +28,9 @@ loadOneXsd(File,(S,G,_))
 
 main 
  :-
-    current_prolog_flag(argv,Argv),
+    % Compatibility hack for >6.4.1 and the use of '--'
+    ( RawArgv = argv ; RawArgv = os_argv ),
+    current_prolog_flag(RawArgv,Argv),
     append(_,['--',XsdFile,BgfFile],Argv),
     loadOneXsd(XsdFile,G1),
     completeXsd(G1,G2),

--- a/shared/prolog/cli/showbgf.pro
+++ b/shared/prolog/cli/showbgf.pro
@@ -2,7 +2,9 @@
 % wiki: ShowBGF
 
 main :- 
-   current_prolog_flag(argv,Argv),
+   % Compatibility hack for >6.4.1 and the use of '--'
+   ( RawArgv = argv ; RawArgv = os_argv ),
+   current_prolog_flag(RawArgv,Argv),
    append(_,['--',BgfXsdFile,BgfXbgfFile,BgfFile],Argv),
    loadXsd(BgfXsdFile,SG),
    loadXml(BgfXbgfFile,BgfXbgfXml),

--- a/shared/prolog/cli/showg.pro
+++ b/shared/prolog/cli/showg.pro
@@ -2,7 +2,9 @@
 % wiki: ShowG
 
 :- 
-   current_prolog_flag(argv,Argv),
+   % Compatibility hack for >6.4.1 and the use of '--'
+   ( RawArgv = argv ; RawArgv = os_argv ),
+   current_prolog_flag(RawArgv,Argv),
    append(_,['--',LgfFile],Argv),
    loadXml(LgfFile,Xml),
    xmlToG(Xml,G),

--- a/shared/prolog/cli/showpnf.pro
+++ b/shared/prolog/cli/showpnf.pro
@@ -2,7 +2,9 @@
 % wiki: ShowPNF
 
 :- 
-   current_prolog_flag(argv,Argv),
+   % Compatibility hack for >6.4.1 and the use of '--'
+   ( RawArgv = argv ; RawArgv = os_argv ),
+   current_prolog_flag(RawArgv,Argv),
    append(_,['--',BtfFile],Argv),
    loadXml(BtfFile,Xml),
    xmlToRoot(Xml,R1),

--- a/shared/prolog/cli/showt.pro
+++ b/shared/prolog/cli/showt.pro
@@ -2,7 +2,9 @@
 % wiki: ShowT
 
 :- 
-   current_prolog_flag(argv,Argv),
+   % Compatibility hack for >6.4.1 and the use of '--'
+   ( RawArgv = argv ; RawArgv = os_argv ),
+   current_prolog_flag(RawArgv,Argv),
    append(_,['--',BtfFile],Argv),
    loadXml(BtfFile,Xml),
    xmlToRoot(Xml,T),

--- a/shared/prolog/cli/showxbgf.pro
+++ b/shared/prolog/cli/showxbgf.pro
@@ -2,7 +2,9 @@
 % wiki: ShowXBGF
 
 main :- 
-   current_prolog_flag(argv,Argv),
+   % Compatibility hack for >6.4.1 and the use of '--'
+   ( RawArgv = argv ; RawArgv = os_argv ),
+   current_prolog_flag(RawArgv,Argv),
    append(_,['--',XbgfXsdFile,XbgfXbgfFile,XbgfFile],Argv),
    loadXsd(XbgfXsdFile,SG),
    loadXml(XbgfXbgfFile,XbgfXbgfXml),

--- a/shared/prolog/cli/showxsd.pro
+++ b/shared/prolog/cli/showxsd.pro
@@ -3,7 +3,9 @@
 
 main 
  :- 
-    current_prolog_flag(argv,Argv),
+    % Compatibility hack for >6.4.1 and the use of '--'
+    ( RawArgv = argv ; RawArgv = os_argv ),
+    current_prolog_flag(RawArgv,Argv),
     append(_,['--',Input],Argv),
     loadXsd(Input,G1),
     completeXsd(G1,G2),

--- a/shared/prolog/cli/stripsxbgf.pro
+++ b/shared/prolog/cli/stripsxbgf.pro
@@ -12,7 +12,9 @@ strips(_,[]).
 strips_rule(X,{X}) :- X = s(_,_).
 
 main :- 
-   current_prolog_flag(argv,Argv),
+   % Compatibility hack for >6.4.1 and the use of '--'
+   ( RawArgv = argv ; RawArgv = os_argv ),
+   current_prolog_flag(RawArgv,Argv),
    append(_,['--',BgfFile,XbgfFile],Argv),
    loadXml(BgfFile,BgfXml),
    xmlToG(BgfXml,g(_,Ps)),

--- a/shared/prolog/cli/striptxbgf.pro
+++ b/shared/prolog/cli/striptxbgf.pro
@@ -12,7 +12,9 @@ stript(_,[]).
 stript_rule(X,{X}) :- X = t(_).
 
 main :- 
-   current_prolog_flag(argv,Argv),
+   % Compatibility hack for >6.4.1 and the use of '--'
+   ( RawArgv = argv ; RawArgv = os_argv ),
+   current_prolog_flag(RawArgv,Argv),
    append(_,['--',BgfFile,XbgfFile],Argv),
    loadXml(BgfFile,BgfXml),
    xmlToG(BgfXml,g(_,Ps)),

--- a/shared/prolog/cli/tdt.pro
+++ b/shared/prolog/cli/tdt.pro
@@ -37,7 +37,9 @@ diffT(RC,((U1,r(G1,T1)),(U2,r(G2,T2))))
 
 
 main :- 
-   current_prolog_flag(argv,Argv),
+   % Compatibility hack for >6.4.1 and the use of '--'
+   ( RawArgv = argv ; RawArgv = os_argv ),
+   current_prolog_flag(RawArgv,Argv),
    append(_,['--'|L1],Argv),
    maplist(loadXml,L1,Xmls),
    maplist(xmlToRoot,Xmls,Ts),

--- a/shared/prolog/cli/xbgf.pro
+++ b/shared/prolog/cli/xbgf.pro
@@ -3,7 +3,9 @@
 
 main 
  :- 
-    current_prolog_flag(argv,Argv),
+    % Compatibility hack for >6.4.1 and the use of '--'
+    ( RawArgv = argv ; RawArgv = os_argv ),
+    current_prolog_flag(RawArgv,Argv),
     append(_,['--',XbgfFile,BgfInFile,BgfOutFile],Argv),
     ( exists_file(BgfOutFile) -> delete_file(BgfOutFile); true ),
     loadXml(XbgfFile, XbgfXml),

--- a/shared/prolog/cli/xbtf.pro
+++ b/shared/prolog/cli/xbtf.pro
@@ -3,7 +3,9 @@
 
 main 
  :- 
-    current_prolog_flag(argv,Argv),
+    % Compatibility hack for >6.4.1 and the use of '--'
+    ( RawArgv = argv ; RawArgv = os_argv ),
+    current_prolog_flag(RawArgv,Argv),
     append(_,['--',XbgfFile,BtfInFile,BtfOutFile],Argv),
     ( exists_file(BtfOutFile) -> delete_file(BtfOutFile); true ),
     loadXml(XbgfFile, XbgfXml),

--- a/shared/prolog/cli/xml2btf.pro
+++ b/shared/prolog/cli/xml2btf.pro
@@ -3,7 +3,9 @@
 
 main 
  :-
-    current_prolog_flag(argv,Argv),
+    % Compatibility hack for >6.4.1 and the use of '--'
+    ( RawArgv = argv ; RawArgv = os_argv ),
+    current_prolog_flag(RawArgv,Argv),
     append(_,['--',XsdFile,XmlFile,BtfFile],Argv),
     loadXsd(XsdFile,SG),
     loadXml(XmlFile,XmlIn),

--- a/shared/prolog/cli/xsd2bgf.pro
+++ b/shared/prolog/cli/xsd2bgf.pro
@@ -3,7 +3,9 @@
 
 main 
  :-
-    current_prolog_flag(argv,Argv),
+    % Compatibility hack for >6.4.1 and the use of '--'
+    ( RawArgv = argv ; RawArgv = os_argv ),
+    current_prolog_flag(RawArgv,Argv),
     append(_,['--',XsdFile,BgfFile],Argv),
     loadXsd(XsdFile,G1),
     completeXsd(G1,G2),

--- a/topics/fl/prolog2/TestEvaluator.pro
+++ b/topics/fl/prolog2/TestEvaluator.pro
@@ -8,7 +8,9 @@ int2literal(I1,literal(I3))
 
 main
  :-
-    current_prolog_flag(argv,Argv),
+    % Compatibility hack for >6.4.1 and the use of '--'
+    ( RawArgv = argv ; RawArgv = os_argv ),
+    current_prolog_flag(RawArgv,Argv),
     append(_,['--',Result1,BtfIn,FName|Ints],Argv),
     atom_chars(Result1,Result2),
     number_chars(Result3,Result2),

--- a/topics/fl/prolog3/TestEvaluator.pro
+++ b/topics/fl/prolog3/TestEvaluator.pro
@@ -8,7 +8,9 @@ int2literal(I1,literal(I3))
 
 main
  :-
-    current_prolog_flag(argv,Argv),
+    % Compatibility hack for >6.4.1 and the use of '--'
+    ( RawArgv = argv ; RawArgv = os_argv ),
+    current_prolog_flag(RawArgv,Argv),
     append(_,['--',Result1,BtfIn,FName|Ints],Argv),
     atom_chars(Result1,Result2),
     number_chars(Result3,Result2),

--- a/topics/semantics/fun/elaborated/main.pro
+++ b/topics/semantics/fun/elaborated/main.pro
@@ -6,6 +6,8 @@
 :- ['erase.pro'].
 
 :-
-    current_prolog_flag(argv,Argv),
+   % Compatibility hack for >6.4.1 and the use of '--'
+   ( RawArgv = argv ; RawArgv = os_argv ),
+   current_prolog_flag(RawArgv,Argv),
     ( append(_,['--',Input],Argv), main(Input), halt; true ).
 

--- a/topics/semantics/lambda/applied/main.pro
+++ b/topics/semantics/lambda/applied/main.pro
@@ -4,6 +4,8 @@
 :- ['../../shared/main/untyped.pro'].
 
 :-
-    current_prolog_flag(argv,Argv),
-    ( append(_,['--',Input],Argv), main(Input), halt; true ).
+   % Compatibility hack for >6.4.1 and the use of '--'
+   ( RawArgv = argv ; RawArgv = os_argv ),
+   current_prolog_flag(RawArgv,Argv),
+   ( append(_,['--',Input],Argv), main(Input), halt; true ).
 

--- a/topics/semantics/lambda/typed/main.pro
+++ b/topics/semantics/lambda/typed/main.pro
@@ -6,6 +6,8 @@
 :- ['erase.pro'].
 
 :-
-    current_prolog_flag(argv,Argv),
-    ( append(_,['--',Input],Argv), main(Input), halt; true ).
+   % Compatibility hack for >6.4.1 and the use of '--'
+   ( RawArgv = argv ; RawArgv = os_argv ),
+   current_prolog_flag(RawArgv,Argv),
+   ( append(_,['--',Input],Argv), main(Input), halt; true ).
 

--- a/topics/semantics/lambda/untyped/main.pro
+++ b/topics/semantics/lambda/untyped/main.pro
@@ -4,6 +4,8 @@
 :- ['../../shared/main/untyped.pro'].
 
 :-
-    current_prolog_flag(argv,Argv),
+    % Compatibility hack for >6.4.1 and the use of '--'
+    ( RawArgv = argv ; RawArgv = os_argv ),
+    current_prolog_flag(RawArgv,Argv),
     ( append(_,['--',Input],Argv), main(Input), halt; true ).
 

--- a/topics/semantics/nb/typed/main.pro
+++ b/topics/semantics/nb/typed/main.pro
@@ -5,5 +5,7 @@
 :- ['../../shared/main/typed.pro'].
 
 :-
-    current_prolog_flag(argv,Argv),
+    % Compatibility hack for >6.4.1 and the use of '--'
+    ( RawArgv = argv ; RawArgv = os_argv ),
+    current_prolog_flag(RawArgv,Argv),
     ( append(_,['--',Input],Argv), main(Input), halt; true ).

--- a/topics/semantics/nb/untyped/main.pro
+++ b/topics/semantics/nb/untyped/main.pro
@@ -4,5 +4,7 @@
 :- ['../../shared/main/untyped.pro'].
 
 :-
-    current_prolog_flag(argv,Argv),
+    % Compatibility hack for >6.4.1 and the use of '--'
+    ( RawArgv = argv ; RawArgv = os_argv ),
+    current_prolog_flag(RawArgv,Argv),
     ( append(_,['--',Input],Argv), main(Input), halt; true ).


### PR DESCRIPTION
The '--' stopped being available after 6.4.1 and so we use os_argv.  See
the changelog for details,
http://www.swi-prolog.org/ChangeLog?branch=stable&from=6.4.1&to=6.6.0

I'm interested in the testmatch.pdf paper, so I've tested the topics/testing subfolder, but I don't have all the rest of the ANTLR/TESCOL stuff working in order to test everything else.