### PR TITLE
Remove unused "singleton branch", caused warning

### DIFF
--- a/shared/prolog/readXbgf.pro
+++ b/shared/prolog/readXbgf.pro
@@ -252,12 +252,10 @@ xml2xbgf(T,F3)
     self(name(xbgf:rename),T),
     (
       child(name(label),T,X),
-      F = renameL,
-      C = label
+      F = renameL
     ;
       child(name(nonterminal),T,X),
-      F = renameN,
-      C = nonterminal
+      F = renameN
     ;
       child(name(selector),T,X),
       (
@@ -268,12 +266,10 @@ xml2xbgf(T,F3)
             )
           ;
             F = renameS([])
-      ),
-      C = selector
+      )
     ;
       child(name(terminal),T,X),
-      F = renameT,
-      C = terminal
+      F = renameT
     ),
     child(name(from),X,From),
     child(name(to),X,To),


### PR DESCRIPTION
At least on,

```
$ swipl --version
SWI-Prolog version 7.2.3 for x86_64-darwin14.5.0
```

I get,

```
Warning: /.../slps/shared/prolog/readXbgf.pro:250:
	Singleton variable in branch: C
```